### PR TITLE
Applet Status Updating

### DIFF
--- a/IFTTT SDK/Applet.swift
+++ b/IFTTT SDK/Applet.swift
@@ -41,10 +41,6 @@ public struct Applet: Equatable {
     
     public internal(set) var status: Status
     
-    mutating func updating(status: Status) {
-        self.status = status
-    }
-    
     public let url: URL
     
     public let services: [Service]

--- a/IFTTT SDK/ConnectInteraction.swift
+++ b/IFTTT SDK/ConnectInteraction.swift
@@ -94,7 +94,8 @@ public class ConnectInteraction {
     public private(set) var applet: Applet
     
     private func appletChangedStatus(isOn: Bool) {
-        applet.updating(status: isOn ? .enabled : .disabled)
+        applet.status =  isOn ? .enabled : .disabled
+        
         if isOn {
             delegate?.connectInteraction(self, appletActivationFinished: .succeeded(applet))
         } else {


### PR DESCRIPTION
### What It Does

- Removes the helper function for updating an `Applet`s status and instead sets the changes directly on the `status` variable.

### Rational

- Because `Applet`'s status is a `private(set) var`, there is already API support for making updates to it and the `func updating(status: Status)` introduces another API that results in the same behavior.

- For consistency in the code base, I'd like to remove the function so that there is one way that you update a `status` in the application.