### PR TITLE
Offline Status Code Crash

### DIFF
--- a/SDK Example/LoginViewController.swift
+++ b/SDK Example/LoginViewController.swift
@@ -78,8 +78,8 @@ class LoginViewController: UIViewController {
                     IFTTTAuthenication.shared.apiExampleOauthToken(token)
                     self.loginIftttUser(token)
                 } else {
-                    // FIXME: - Will crash if offline because status code is nil.
-                    self.loginFailed(statusCode!)
+                    // FIXME: - Will crash if offline because status code is nil. Adding temporary solution.
+                    self.loginFailed(statusCode ?? 404)
                 }
             }
         }.resume()


### PR DESCRIPTION
### What It Does

- Adds a `FIXME` note about a crash I accounted while using the app offline on an airplane. 

- Temporarily setting the default case to `404`.