### PR TITLE
Updating Notification Name to Constant

### DIFF
--- a/IFTTT SDK/Applet.swift
+++ b/IFTTT SDK/Applet.swift
@@ -71,9 +71,7 @@ public protocol TokenProviding {
 }
 
 extension Notification.Name {
-    static var iftttAppletActivationRedirect: Notification.Name {
-        return Notification.Name("ifttt.applet.activation.redirect")
-    }
+    static let iftttAppletActivationRedirect = Notification.Name("ifttt.applet.activation.redirect")
 }
 
 public extension Applet {


### PR DESCRIPTION
### What It Does

- Switching to a constant instead of a computed variable.