### PR TITLE
When a Connection requires configuration on web, show different copy after authorizing a service

### DIFF
--- a/IFTTT SDK/Localizable.strings
+++ b/IFTTT SDK/Localizable.strings
@@ -13,6 +13,7 @@
 "button.state.accessing_existing_account" = "Accessing IFTTT account…"; // FIXME: Need copy!
 "button.state.sign_in" = "Sign in to %@";
 "button.state.sign_in.brief" = "Sign in";
+"button.state.saving_configuration" = "Saving settings…";
 "button.state.connecting" = "Connecting account…";
 "button.state.connected" = "Connected";
 "button.state.disconnecting" = "Disconnecting…";


### PR DESCRIPTION
- Redirects from web now include a parameter `config=true`. When this is included, the `Connection` included a configuration step on web. This will only be present when the `Connection` authorization is completed (The last step).
 
- For now, ignore this during the login complete step. It's possible that all the services are already connected and we only had to do a configuration on web. We don't have design for this and my intuition says we shouldn't do anything different in this scenario. I will check with product and design. If any changes are needed, we'll do it in another PR.

- This also includes some renaming for service connection to service authorization and some added comments for areas of the code this touched. 