### PR TITLE
Breaking up func transition(to activationStep: ActivationStep)

### DIFF
--- a/IFTTT SDK/ConnectButtonController.swift
+++ b/IFTTT SDK/ConnectButtonController.swift
@@ -512,8 +512,6 @@ public class ConnectButtonController {
         switch lookupMethod {
         case .email:
             button.animator(for: .buttonState(.step(for: nil, message: "button.state.checking_account".localized), footerValue: FooterMessages.poweredBy.value)).preform()
-            
-            
         case .token:
             button.animator(for: .buttonState(.step(for: nil, message: "button.state.accessing_existing_account".localized), footerValue: FooterMessages.poweredBy.value)).preform()
         }


### PR DESCRIPTION
### What It Does

- Breaks up `func transition(to activationStep: ActivationStep)` to use helper functions for readability and single responsibility.

### Notes

- I'm in process of trying to solve for the unhandled button states. This is a step in the process.

- I didn't do much refactoring in any of the code in each helper function. Just focused on breaking this up.