### PR TITLE
Fixes ConnectButton state transition crash

### DIFF
--- a/IFTTT SDK/ConnectButton.swift
+++ b/IFTTT SDK/ConnectButton.swift
@@ -141,6 +141,12 @@ public class ConnectButton: UIView {
         let animator = Animator(animator: UIViewPropertyAnimator(duration: 0.5,
                                                                  timingParameters: UISpringTimingParameters(dampingRatio: 1)))
         if let state = transition.state {
+            // We currently can't support interrupting animations with other touch events
+            // This is due to the way that we update 'currentState' in the animation completion
+            // Animations must complete before we will respond to the next event
+            // Note: This does not effect dragging the toggle since any ongoing touch events will continue
+            animator.animator.isUserInteractionEnabled = false
+            
             animator.animator.addCompletion { (position) in
                 if position == .end {
                     self.currentState = state


### PR DESCRIPTION
https://github.com/IFTTT/IFTTT-SDK-iOS-Sandbox-/issues/19

**Issue**
The `ConnectButton` receives an unrecognized state transition if the user taps the email button before the toggle on animation completes. 

**Solution**
Disable user interaction in the animator. This blocks state transitions initiated from the UI until the previous state transition finishes. 