### PR TITLE
Adding SDK Version to ActivationURL

### DIFF
--- a/IFTTT SDK/Connection+URLGeneration.swift
+++ b/IFTTT SDK/Connection+URLGeneration.swift
@@ -38,7 +38,9 @@ extension Connection {
     }
     
     private func queryItems(for step: ActivationStep, tokenProvider: CredentialProvider, activationRedirect: URL) -> [URLQueryItem] {
-        var queryItems = [URLQueryItem(name: URLQueryItemConstants.sdkReturnName, value: activationRedirect.absoluteString), URLQueryItem(name: URLQueryItemConstants.sdkVersionName, value: URLQueryItemConstants.sdkVersionValue), URLQueryItem(name: URLQueryItemConstants.sdkPlatformName, value: URLQueryItemConstants.sdkPlatformValue)]
+        var queryItems = [URLQueryItem(name: URLQueryItemConstants.sdkReturnName, value: activationRedirect.absoluteString),
+                          URLQueryItem(name: URLQueryItemConstants.sdkVersionName, value: URLQueryItemConstants.sdkVersionValue),
+                          URLQueryItem(name: URLQueryItemConstants.sdkPlatformName, value: URLQueryItemConstants.sdkPlatformValue)]
         
         if let inviteCode = tokenProvider.inviteCode {
             queryItems.append(URLQueryItem(name: URLQueryItemConstants.inviteCodeName, value: inviteCode))


### PR DESCRIPTION
### What It Does

- Adds a `sdk_version` to the creation of the `activationURL`.

- Example:
```
https://ifttt.com/access/api/mZRHhST7?sdk_return_to=ifttt-api-example://sdk-callback&sdk_version=2.0.0-alpha2&invite_code=&skip_sdk_redirect=true&email=&sdk_create_account=true
```