### PR TITLE
Removes redirect state transitions from initial state

### DIFF
--- a/IFTTT SDK/ConnectButtonController.swift
+++ b/IFTTT SDK/ConnectButtonController.swift
@@ -242,10 +242,17 @@ public class ConnectButtonController {
     class SafariDelegate: NSObject, SFSafariViewControllerDelegate {
         /// Callback when the Safari VC is dismissed by the user
         /// This triggers a cancelation event
-        var onCancelation: (() -> Void)?
+        let onCancelation: () -> Void
+        
+        /// Create a new SafariDelegate
+        ///
+        /// - Parameter onCancelation: The cancelation handler
+        init(onCancelation: @escaping () -> Void) {
+            self.onCancelation = onCancelation
+        }
         
         func safariViewControllerDidFinish(_ controller: SFSafariViewController) {
-            onCancelation?()
+            onCancelation()
         }
     }
     
@@ -431,8 +438,7 @@ public class ConnectButtonController {
             self?.button.addConnectionLog(redirectLog)
         }
         
-        safariDelegate = SafariDelegate()
-        safariDelegate?.onCancelation = { [weak self] in
+        safariDelegate = SafariDelegate { [weak self] in
             self?.handleCancelation()
         }
     }


### PR DESCRIPTION
**Why**
There is an invalid state transition from the initial state to service connection. This transition originates from a redirect after the flow was canceled. This invalid transition was not enforced by the `ConnectButtonController`. Here is the invalid flow:
```
▿ ConnectionDiary
  ▿ activationStateLog : 10 elements
    - 0 : "nil to initial"
    - 1 : "initial to identifyUser"
    - 2 : "identifyUser to logInExistingUser"
    - 3 : "Redirect Parameters:\nnext_step: service_authentication\nservice_id: spotify"
    - 4 : "logInExistingUser to logInComplete"
    - 5 : "logInComplete to serviceAuthentication"
    - 6 : "serviceAuthentication to canceled"
    - 7 : "canceled to initial"
    - 8 : "Redirect Parameters:\nnext_step: service_authentication\nservice_id: spotify"
    - 9 : "initial to serviceAuthentication"
```

**How**
- Removes cancelation observation responsibility from `RedirectObserving` in to a new type `SafariDelegate`. 
- Removes redirect observation when in the `initial` or `connected` state. This enforces a rule against the invalid state transition described above. 