### PR TITLE
Fixes username based login for the existing user connect flow

### DIFF
--- a/IFTTT SDK/Connection+URLGeneration.swift
+++ b/IFTTT SDK/Connection+URLGeneration.swift
@@ -13,7 +13,6 @@ extension Connection {
     private enum URLQueryItemConstants {
         static let sdkReturnName = "sdk_return_to"
         static let inviteCodeName = "invite_code"
-        static let userIdName = "user_id"
         static let emailName = "email"
         static let skipSDKRedirectName = "skip_sdk_redirect"
         static let sdkCreatAccountName = "sdk_create_account"
@@ -55,13 +54,7 @@ extension Connection {
     }
     
     private func queryItemForLogin( userId: User.Id) -> URLQueryItem {
-        switch userId {
-        case let .username(username):
-            // FIXME: Verify this param name when we have it
-            return URLQueryItem(name: URLQueryItemConstants.userIdName, value: username)
-        case let .email(email):
-            return URLQueryItem(name: URLQueryItemConstants.emailName, value: email)
-        }
+        return URLQueryItem(name: URLQueryItemConstants.emailName, value: userId.value)
     }
     
     private func queryItemsforServiceConnection(userEmail: String?, token: String?) -> [URLQueryItem] {

--- a/IFTTT SDK/User.swift
+++ b/IFTTT SDK/User.swift
@@ -11,6 +11,15 @@ import Foundation
 struct User {
     enum Id {
         case username(String), email(String)
+        
+        var value: String {
+            switch self {
+            case .username(let username):
+                return username
+            case .email(let email):
+                return email
+            }
+        }
     }
     
     /// We know something about a user when they begin a connect button flow.


### PR DESCRIPTION
The new login page for the connect flow is ready. It always uses the `email` parameter whether we pass the username or email. Remove the `user_id` param. 