### PR TITLE
Fixes color of email confirm button on cancel

### DIFF
--- a/IFTTT SDK/ConnectButton.swift
+++ b/IFTTT SDK/ConnectButton.swift
@@ -1228,7 +1228,6 @@ private extension ConnectButton {
             animator.addAnimations {
                 self.emailEntryField.alpha = 0
                 self.emailConfirmButton.alpha = 0
-                self.emailConfirmButton.backgroundColor = Style.Color.grey
                 
                 self.backgroundView.backgroundColor = service?.brandColor ?? Style.Color.grey
                 
@@ -1239,7 +1238,6 @@ private extension ConnectButton {
                 self.backgroundView.border.opacity = 1
             }
             animator.addCompletion { (_) in
-                self.emailConfirmButton.backgroundColor = .black
                 self.emailConfirmButton.transform = .identity
             }
             


### PR DESCRIPTION
**What it fixes**
- Begin a connection flow in dark mode
- Cancel the flow after entering an email 
- Restart the flow
The email confirm button is now black instead of white

**How**
Removes code which adjusted the email confirm button's background color during an animation. Simply fade the button instead. 