### PR TITLE
Fixes missing service icon in existing user flow

### DIFF
--- a/IFTTT SDK/ConnectButton.swift
+++ b/IFTTT SDK/ConnectButton.swift
@@ -1248,6 +1248,7 @@ private extension ConnectButton {
             progressBar.configure(with: service)
             primaryLabelAnimator.transition(with: .rotateDown,
                                             updatedValue: .text(message),
+                                            insets: service == nil ? .standard : .avoidServiceIcon,
                                             addingTo: animator)
             
             imageViewNetworkController?.setImage(with: service?.standardIconURL, for: self.serviceIconView)


### PR DESCRIPTION
**The bug**
- Sign into the example app with an existing account with both service already connected
- Turn on the applet
- After returning from safari, the service icon is missing in the "Connecting account..." state

**Fix**
Set the service icon when transition between steps. This will be a no-op if the icon doesn't change. 

**Some thoughts...**
We have made several fixes like this. There are a lot of possible states. I definitely agree we need more structure. We were supporting `step` to `step` transitions with the intention of changing just the text. Unintentionally it was also used for the transition between "Accessing your account" and "Connecting account..." if everything was already connected. I think we need to do away with inspecting the previous state versus current state and have discreet states for each possible transition. Which I think is the direction you were recommending. Not the right place to discuss this but I think we should plan to make this change before the March 5 launch. 