### PR TITLE
Adds IFTTT app store page to connected button state

### DIFF
--- a/IFTTT SDK/API.swift
+++ b/IFTTT SDK/API.swift
@@ -10,6 +10,9 @@ import Foundation
 
 struct API {
     
+    /// The unique id for IFTTT's App Store listing
+    static let iftttAppStoreId = "660944635"
+    
     static let sdkVersion = "2.0.0-alpha4"
     static let sdkPlatform = "ios"
     


### PR DESCRIPTION
Fixes a missing product requirement. When the Connection is enabled, we should link to the IFTTT App Store page, not our about page. 