### PR TITLE
Removing Checkmark and ServiceIconView

### DIFF
--- a/IFTTT SDK/ConnectButton.swift
+++ b/IFTTT SDK/ConnectButton.swift
@@ -1204,7 +1204,7 @@ private extension ConnectButton {
             
             primaryLabelAnimator.transition(with: .crossfade,
                                             updatedValue: .text(message),
-                                            insets: service == nil ? .standard : .avoidServiceIcon,
+                                            insets: .standard,
                                             addingTo: animator)
             
             animator.addAnimations {
@@ -1226,7 +1226,7 @@ private extension ConnectButton {
             progressBar.configure(with: service)
             primaryLabelAnimator.transition(with: .rotateDown,
                                             updatedValue: .text(message),
-                                            insets: service == nil ? .standard : .avoidServiceIcon,
+                                            insets: .standard,
                                             addingTo: animator)
             
             animator.addAnimations {

--- a/IFTTT SDK/ConnectButtonController.swift
+++ b/IFTTT SDK/ConnectButtonController.swift
@@ -769,16 +769,8 @@ public class ConnectButtonController {
                         
                         progress.resume(with: UISpringTimingParameters(dampingRatio: 1), duration: 1.5)
                         progress.onComplete { position in
-                            
                             if position == .end {
-                                // Show "fake" success
-                                self.button.animator(for: .buttonState(.stepComplete(for: nil))).preform()
-                                
-                                // After a short delay, show first service connection
-                                DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
-                                    // We know that this is a new user so we must connect the primary service first and create an account
-                                    self.transition(to: .serviceAuthentication(self.connectingService, newUserEmail: email))
-                                }
+                                self.transition(to: .serviceAuthentication(self.connectingService, newUserEmail: email))
                             }
                         }
                     } else { // Existing IFTTT user


### PR DESCRIPTION
### What It Does

- Removes the `ServiceIconView` because it is no longer used or needed in the flow.

- Removes showing a checkmark after an account is created.

### Screenshot
![feb-13-2019 15-15-50](https://user-images.githubusercontent.com/16432044/52740980-547a0100-2fa2-11e9-8e02-36ed71bbb71a.gif)
