### PR TITLE
Adds anonymous id to all SDK requests

### DIFF
--- a/IFTTT SDK/API.swift
+++ b/IFTTT SDK/API.swift
@@ -16,6 +16,17 @@ struct API {
     static let sdkVersion = "2.0.0-alpha5"
     static let sdkPlatform = "ios"
     
+    /// An installation id for this instance of the SDK. This id remains static from installation to deletion of the partner app.
+    static var anonymousId: String {
+        if let id = UserDefaults.standard.string(forKey: Keys.anonymousIdKey) {
+            return id
+        } else {
+            let id = UUID().uuidString
+            UserDefaults.standard.set(id, forKey: Keys.anonymousIdKey)
+            return id
+        }
+    }
+    
     private struct URLConstants {
         static let base = "https://api.ifttt.com/v2"
         static let findEmail = "/account/find?email="
@@ -29,4 +40,8 @@ struct API {
     }
     
     static let findUserByToken = URL(string: "\(API.URLConstants.base)\(API.URLConstants.me)")!
+    
+    private struct Keys {
+        static let anonymousIdKey = "com.ifttt.sdk.analytics.anonymous_id"
+    }
 }

--- a/IFTTT SDK/Connection+URLGeneration.swift
+++ b/IFTTT SDK/Connection+URLGeneration.swift
@@ -23,6 +23,7 @@ extension Connection {
             static let defaultTrueValue = "true"
             static let sdkVersionName = "sdk_version"
             static let sdkPlatformName = "sdk_platform"
+            static let sdkAnonymousId = "sdk_anonymous_id"
         }
     }
     
@@ -60,7 +61,8 @@ extension Connection {
     private func queryItems(for step: ActivationStep, credentialProvider: CredentialProvider, activationRedirect: URL) -> [URLQueryItem] {
         var queryItems = [URLQueryItem(name: Constants.QueryItem.sdkReturnName, value: activationRedirect.absoluteString),
                           URLQueryItem(name: Constants.QueryItem.sdkVersionName, value: API.sdkVersion),
-                          URLQueryItem(name: Constants.QueryItem.sdkPlatformName, value: API.sdkPlatform)]
+                          URLQueryItem(name: Constants.QueryItem.sdkPlatformName, value: API.sdkPlatform),
+                          URLQueryItem(name: Constants.QueryItem.sdkAnonymousId, value: API.anonymousId)]
         
         if let inviteCode = credentialProvider.inviteCode {
             queryItems.append(URLQueryItem(name: Constants.QueryItem.inviteCodeName, value: inviteCode))

--- a/IFTTT SDK/URLRequest+CommonValues.swift
+++ b/IFTTT SDK/URLRequest+CommonValues.swift
@@ -14,6 +14,7 @@ extension URLRequest {
         static let inviteCode = "IFTTT-Invite-Code"
         static let sdkVersion = "IFTTT-SDK-Version"
         static let sdkPlatform = "IFTTT-SDK-Platform"
+        static let sdkAnonymousId = "IFTTT-SDK-Anonymous-Id"
     }
     
     mutating func addIftttServiceToken(_ token: String) {
@@ -28,5 +29,6 @@ extension URLRequest {
     mutating func addVersionTracking() {
         setValue(API.sdkVersion, forHTTPHeaderField: HeaderFields.sdkVersion)
         setValue(API.sdkPlatform, forHTTPHeaderField: HeaderFields.sdkPlatform)
+        setValue(API.anonymousId, forHTTPHeaderField: HeaderFields.sdkAnonymousId)
     }
 }


### PR DESCRIPTION
IFTTT-1482
https://ifttt-dev.atlassian.net/browse/IFTTT-1482

**What it does**
- Adds `anonymousId` to sdk versioning information that is included with API requests
- Adds this to the activation URL, connection requests, and requests made by the connect button controller

**What it is**
- `anonymousId` is really an installation ID used for associating non-authenticated API requests with a user. 

Because I'm having an issue with Charles, this is debug output. Anonymous IDs are matching.
<img width="669" alt="screen shot 2019-02-25 at 12 04 28 pm" src="https://user-images.githubusercontent.com/7697222/53367176-53c66080-38fa-11e9-8da8-4b8d335372cb.png">
<img width="1134" alt="screen shot 2019-02-25 at 12 05 28 pm" src="https://user-images.githubusercontent.com/7697222/53367187-57f27e00-38fa-11e9-9951-4f5fc5bdb8ec.png">
