### PR TITLE
Enabling Email Suggestion Bar

### DIFF
--- a/IFTTT SDK/ConnectButton.swift
+++ b/IFTTT SDK/ConnectButton.swift
@@ -537,7 +537,6 @@ public class ConnectButton: UIView {
     fileprivate let emailEntryField: UITextField = {
         let field = UITextField(frame: .zero)
         field.keyboardType = .emailAddress
-        field.autocorrectionType = .no
         field.autocapitalizationType = .none
         return field
     }()


### PR DESCRIPTION
### What It Does

- Enables auto correct which will allow the iOS to suggest your saved e-mails.