### PR TITLE
Invalid email text changes

### DIFF
--- a/IFTTT SDK/ConnectButtonController.swift
+++ b/IFTTT SDK/ConnectButtonController.swift
@@ -190,6 +190,8 @@ public class ConnectButtonController {
         disconnect
 
         private struct Constants {
+            static let errorTextColor: UIColor = .red
+            
             static var footnoteFont: UIFont {
                 return .footnote()
             }
@@ -229,12 +231,11 @@ public class ConnectButtonController {
 
             case .emailInvalid:
                 let text = "button.footer.email.invalid".localized
-                return NSAttributedString(string: text, attributes: [.font : Constants.footnoteFont, .foregroundColor : UIColor.red])
+                return NSAttributedString(string: text, attributes: [.font : Constants.footnoteFont, .foregroundColor : Constants.errorTextColor])
 
             case .verifying(let email):
                 let text = NSMutableAttributedString(string: "button.footer.email.sign_in".localized(with: email), attributes: [.font : Constants.footnoteFont])
-                let changeEmailText = NSAttributedString(string: "button.footer.email.change_email".localized, attributes: [.font : Constants.footnoteBoldFont,
-                                                                                                                            .underlineStyle : NSUnderlineStyle.single.rawValue])
+                let changeEmailText = NSAttributedString(string: "button.footer.email.change_email".localized, attributes: [.font : Constants.footnoteBoldFont, .underlineStyle : NSUnderlineStyle.single.rawValue])
                 text.append(changeEmailText)
                 return text
 


### PR DESCRIPTION
### What It Does

- Changes the invalid e-mail footer text color to red

- Adds a timer that resets the footer text to its previous value after a few seconds.


### Screenshot
![feb-26-2019 12-52-04](https://user-images.githubusercontent.com/16432044/53435086-07485700-39c6-11e9-9894-ec9d5197efd7.gif)
