### PR TITLE
Fixing Touch Down Highlighting

### DIFF
--- a/IFTTT SDK/ConnectButton.swift
+++ b/IFTTT SDK/ConnectButton.swift
@@ -411,7 +411,6 @@ public class ConnectButton: UIView {
         switchControl.addGestureRecognizer(toggleTapGesture)
         toggleTapGesture.delaysTouchesBegan = true
         toggleTapGesture.delegate = self
-        toggleTapGesture.performHighlight = nil
         
         switchControl.addGestureRecognizer(toggleDragGesture)
         toggleDragGesture.delegate = self


### PR DESCRIPTION
### What It Does

- It seems we were disabling the highlight functionality for the button. 

- I removed the line and tested out the flow. Seems to work now.