### PR TITLE
Fix dependency issue on the controller from the connect button

### DIFF
--- a/IFTTT SDK/ConnectButton.swift
+++ b/IFTTT SDK/ConnectButton.swift
@@ -1210,7 +1210,6 @@ private extension ConnectButton {
     
     private func transitionToLoading(animator: UIViewPropertyAnimator) {
         primaryLabelAnimator.configure(.text("button.state.loading".localized), insets: .standard)
-        footerLabelAnimator.configure(ConnectButtonController.FooterMessages.worksWithIFTTT.value)
         
         animator.addAnimations {
             self.backgroundView.backgroundColor = .black

--- a/IFTTT SDK/ConnectButtonController.swift
+++ b/IFTTT SDK/ConnectButtonController.swift
@@ -155,6 +155,7 @@ public class ConnectButtonController {
     }
 
     private func fetchConnection(for id: String) {
+        button.animator(for: .footerValue(FooterMessages.worksWithIFTTT.value)).preform(animated: false)
         button.animator(for: .buttonState(.loading)).preform(animated: true)
 
         connectionNetworkController.start(request: .fetchConnection(for: id, credentialProvider: credentialProvider)) { [weak self] response in


### PR DESCRIPTION
In the connect button's loading state, moves the footer configuration to the controller to remove the dependency. 