### PR TITLE
IFTTT-1721 - Connect button dark mode design tweaks

### DIFF
--- a/IFTTT SDK/ConnectButton.swift
+++ b/IFTTT SDK/ConnectButton.swift
@@ -13,12 +13,12 @@ import UIKit
 fileprivate struct Layout {
     static let height: CGFloat = 64
     static let maximumWidth = 6 * height
-    static let knobInset: CGFloat = 4
+    static let knobInset: CGFloat = 6
     static let knobDiameter = height - 2 * knobInset
     static let checkmarkDiameter: CGFloat = 42
     static let checkmarkLength: CGFloat = 14
     static let serviceIconDiameter = 0.5 * knobDiameter
-    static let borderWidth: CGFloat = 2
+    static let borderWidth: CGFloat = 2.5
     static let buttonFooterSpacing: CGFloat = 20
 }
 
@@ -46,7 +46,7 @@ public class ConnectButton: UIView {
             static let blue = UIColor(hex: 0x0099FF)
             static let lightGrey = UIColor(hex: 0xCCCCCC)
             static let grey = UIColor(hex: 0x414141)
-            static let border = UIColor(white: 1, alpha: 0.2)
+            static let border = UIColor(white: 1, alpha: 0.32)
         }
     }
     


### PR DESCRIPTION
https://ifttt-dev.atlassian.net/browse/IFTTT-1721

### What It Does

- Adjusts the color and width of the dark mode border.

- Adjusts the knob inset to match the design. Makes the border feel larger.

### Screenshot

Before:
![Simulator Screen Shot - iPhone Xs - 2019-04-16 at 15 43 57](https://user-images.githubusercontent.com/16432044/56240477-a94cfd00-6061-11e9-950f-544266c2a095.png)

After:
![Simulator Screen Shot - iPhone Xs - 2019-04-16 at 16 06 38](https://user-images.githubusercontent.com/16432044/56240478-ab16c080-6061-11e9-9024-e81077c37fed.png)
