### PR TITLE
IFTTT-1751 - Connect button loses icon on reset

### DIFF
--- a/IFTTT SDK/ConnectButton.swift
+++ b/IFTTT SDK/ConnectButton.swift
@@ -1217,6 +1217,7 @@ private extension ConnectButton {
             self.switchControl.isOn = false
             self.switchControl.knob.alpha = 1
             self.switchControl.knob.maskedEndCaps = .all
+            self.switchControl.knob.iconView.alpha = 1
             self.switchControl.alpha = 1
             
             // This is only relevent for dark mode when we draw a border around the switch


### PR DESCRIPTION
https://ifttt-dev.atlassian.net/browse/IFTTT-1751

### What It Does

- Makes sure that the icon view is shown when going into the connect state.

### Gif
![Apr-16-2019 16-26-35](https://user-images.githubusercontent.com/16432044/56241735-9daf0580-6064-11e9-9e98-bb67ef9b373c.gif)
