### PR TITLE
IFTTT-1722: Extracts the user token from the activation completion redirect

### DIFF
--- a/Grocery Express/ConnectionViewController.swift
+++ b/Grocery Express/ConnectionViewController.swift
@@ -128,13 +128,12 @@ extension ConnectionViewController: ConnectButtonControllerDelegate {
     }
     
     func connectButtonController(_ connectButtonController: ConnectButtonController,
-                                 didFinishActivationWithResult result: Result<Connection, ConnectButtonControllerError>,
-                                 userToken: String?) {
+                                 didFinishActivationWithResult result: Result<ConnectionActivation, ConnectButtonControllerError>) {
         switch result {
-        case .success:
+        case .success(let activation):
             // A Connection was activated and we received the user's service-level IFTTT token
             // Let's update our credential for this user
-            if let token = userToken {
+            if let token = activation.userToken {
                 connectionCredentials.loginUser(with: token)
             }
             

--- a/IFTTT SDK/ConnectButtonController.swift
+++ b/IFTTT SDK/ConnectButtonController.swift
@@ -9,6 +9,16 @@
 import UIKit
 import SafariServices
 
+/// Bundles values when a Connection is activated
+public struct ConnectionActivation {
+    
+    /// The IFTTT service-level user token for your service.
+    public let userToken: String?
+    
+    /// The Connection that was activated
+    public let connection: Connection
+}
+
 /// An error occurred, preventing a connect button from completing a service authentication with the `Connection`.
 public enum ConnectButtonControllerError: Error {
 
@@ -54,10 +64,8 @@ public protocol ConnectButtonControllerDelegate: class {
     /// - Parameters:
     ///   - connectButtonController: The `ConnectButtonController` controller that is sending the message.
     ///   - result: A result of the connection activation request.
-    ///   - userToken: The IFTTT service-level user token for your service.
     func connectButtonController(_ connectButtonController: ConnectButtonController,
-                                 didFinishActivationWithResult result: Result<Connection, ConnectButtonControllerError>,
-                                 userToken: String?)
+                                 didFinishActivationWithResult result: Result<ConnectionActivation, ConnectButtonControllerError>)
 
     /// Connection deactivation is finished.
     ///
@@ -94,13 +102,14 @@ public class ConnectButtonController {
     private func handleActivationFinished(userToken: String?) {
         connection?.status = .enabled
         if let connection = connection {
-            delegate?.connectButtonController(self, didFinishActivationWithResult: .success(connection),
-                                              userToken: userToken)
+            let activation = ConnectionActivation(userToken: userToken,
+                                                  connection: connection)
+            delegate?.connectButtonController(self, didFinishActivationWithResult: .success(activation))
         }
     }
     
     private func handleActivationFailed(error: ConnectButtonControllerError) {
-        delegate?.connectButtonController(self, didFinishActivationWithResult: .failure(error), userToken: nil)
+        delegate?.connectButtonController(self, didFinishActivationWithResult: .failure(error))
     }
     
     private func handleDeactivationFinished() {


### PR DESCRIPTION
https://ifttt-dev.atlassian.net/browse/IFTTT-1722

This makes it a little easier to adopt the SDK

**Changes**
- Creates a new delegate callback to pass the token. This allows us to not require it and not make it optional. It should always be there be let's not stop the flow if it isn't.
- Catches a applet -> connection rename
- Removes did configuration from completion redirect as it's not used 

**Testing**
Do the new user or returning user flow. Return to the grocery express menu and ensure that you are logged in. 