### PR TITLE
IFTTT-1656 - Button morphing animation is broken when dragging back and forth and then go back

### DIFF
--- a/IFTTT SDK/ConnectButton.swift
+++ b/IFTTT SDK/ConnectButton.swift
@@ -363,7 +363,11 @@ public class ConnectButton: UIView {
             }
             let timing = UISpringTimingParameters(dampingRatio: 1,
                                                   initialVelocity: CGVector(dx: v, dy: 0))
+            self.isUserInteractionEnabled = false
             animation.continueAnimation(withTimingParameters: timing, durationFactor: 1)
+            animation.addCompletion { [weak self] _ in
+                self?.isUserInteractionEnabled = true
+            }
             currentToggleAnimation = nil
             
         case .cancelled, .failed:


### PR DESCRIPTION
https://ifttt-dev.atlassian.net/browse/IFTTT-1656

### What It Does

- Disabled interaction when we are animating the button back to the starting location.

### Example
https://ifttt.slack.com/archives/C04CP9KPR/p1555531667007000