### PR TITLE
Slightly widen the connect button's max width

### DIFF
--- a/IFTTT SDK/ConnectButton.swift
+++ b/IFTTT SDK/ConnectButton.swift
@@ -12,7 +12,7 @@ import UIKit
 
 fileprivate struct Layout {
     static let height: CGFloat = 70
-    static let maximumWidth = 4.5 * height
+    static let maximumWidth = 4.7 * height
     static let knobInset: CGFloat = 4
     static let knobDiameter = height - 2 * knobInset
     static let checkmarkDiameter: CGFloat = 42


### PR DESCRIPTION
It felt a little too narrow on my huge iPhone. The ratio based on the Sketch file is actually 4.625. I rounded up to 4.7. I think this is a little better. 

**Before**
![before](https://user-images.githubusercontent.com/7697222/56765410-f6715300-6774-11e9-8250-fb11bf523242.jpeg)

**After**
![after](https://user-images.githubusercontent.com/7697222/56765409-f6715300-6774-11e9-8412-5d5b18fa4a61.jpeg)
