### PR TITLE
Fixes misplaced knob when loading button into the connected state

### DIFF
--- a/IFTTT SDK/ConnectButton.swift
+++ b/IFTTT SDK/ConnectButton.swift
@@ -1460,6 +1460,8 @@ private extension ConnectButton {
             animator.addAnimations {
                 self.switchControl.isOn = true
             }
+        } else {
+            switchControl.isOn = true
         }
         
         animator.addAnimations {


### PR DESCRIPTION
If you loaded the button and the connection was already enabled, the toggle was in the off position. 