### PR TITLE
Fixes issue where knob would be expanded on an error

### DIFF
--- a/IFTTT SDK/ConnectButton.swift
+++ b/IFTTT SDK/ConnectButton.swift
@@ -1327,16 +1327,20 @@ private extension ConnectButton {
             self.emailEntryField.alpha = 1
         }, delayFactor: 0.7)
         
+        let resetKnob = {
+            // Keep the knob is a "clean" state since we don't animate backwards from this step
+            self.switchControl.knob.transform = .identity
+            self.switchControl.knob.maskedEndCaps = .all // reset
+            self.switchControl.knob.layer.shadowOpacity = 0.25
+            self.switchControl.configure(with: service, networkController: self.imageViewNetworkController)
+            self.switchControl.knob.iconView.alpha = 1.0
+        }
+        
         animator.addCompletion { position in
             
             switch position {
             case .start:
-                // Keep the knob is a "clean" state since we don't animate backwards from this step
-                self.switchControl.knob.transform = .identity
-                self.switchControl.knob.maskedEndCaps = .all // reset
-                self.switchControl.knob.layer.shadowOpacity = 0.25
-                self.switchControl.configure(with: service, networkController: self.imageViewNetworkController)
-                self.switchControl.knob.iconView.alpha = 1.0
+                resetKnob()
                 self.emailEntryField.alpha = 0.0
                 
                 self.switchControl.isOn = false
@@ -1360,6 +1364,7 @@ private extension ConnectButton {
                     if suggestedEmail == nil || shouldBecomeFirstResponder {
                         self.emailEntryField.becomeFirstResponder()
                     }
+                    resetKnob()
                 }
                 
                 endAnimator.startAnimation()


### PR DESCRIPTION
https://ifttt-dev.atlassian.net/browse/IFTTT-1795

This was reproducible by doing the new account flow. Hitting cancel on the last step on the google auth flow. The page where it gives the options "allow" or "cancel". 

The knob was in an inconsistent state since we didn't reset it on a completed transition to email. 