### PR TITLE
Fixes the creating account footer and slows animation timing

### DIFF
--- a/IFTTT SDK/ConnectButtonController.swift
+++ b/IFTTT SDK/ConnectButtonController.swift
@@ -726,9 +726,12 @@ public class ConnectButtonController {
                     // Show a fake message that we are creating an account
                     // Then move to the first step of the service connection flow
                     progress.wait(until: 0.5) {
-                        self.button.animator(for: .buttonState(.createAccount(message: "button.state.creating_account".localized))).perform()
+                        self.button.animator(for: .buttonState(
+                            .createAccount(message: "button.state.creating_account".localized),
+                            footerValue: FooterMessages.creatingAccount(email: user.id.value).value)
+                            ).perform()
                         
-                        progress.finish {
+                        progress.finish(extendingDurationBy: 1.5) {
                             self.transition(to: .activateConnection(user))
                         }
                     }


### PR DESCRIPTION
I think we lost the creating account footer in a merge conflict. This also slows the timing just a bit. 

![creating-account](https://user-images.githubusercontent.com/7697222/56829025-a48e0300-6830-11e9-8c6f-22be663cd069.gif)
