### PR TITLE
Fixes issue where isExistingUser was false for a logged in user

### DIFF
--- a/IFTTT SDK/ConnectionNetworkController.swift
+++ b/IFTTT SDK/ConnectionNetworkController.swift
@@ -103,8 +103,8 @@ public final class ConnectionNetworkController {
             }
             
             let dataTask = urlSession.jsonTask(with: request) { _, response, error in
-                let configuration = User(id: .email(email), isExistingUser: response?.statusCode == 204)
-                completion(.success(configuration))
+                let user = User(id: .email(email), isExistingUser: response?.statusCode == 204)
+                completion(.success(user))
                 
             }
             dataTask.resume()
@@ -121,8 +121,8 @@ public final class ConnectionNetworkController {
                     return
                 }
                 
-                let configuration = User(id: .username(username), isExistingUser: true)
-                completion(.success(configuration))
+                let user = User(id: .username(username), isExistingUser: true)
+                completion(.success(user))
             }
             dataTask.resume()
             


### PR DESCRIPTION
Fixes: 
https://ifttt-dev.atlassian.net/browse/IFTTT-1809 & 
https://ifttt-dev.atlassian.net/browse/IFTTT-1796

This has been wrong for a very long time. I think we never caught it because the logged in user flow was taking a different path until we consolidated flows. 