### PR TITLE
IFTTT-1821: Going To Service State

### DIFF
--- a/IFTTT SDK/ConnectButtonController.swift
+++ b/IFTTT SDK/ConnectButtonController.swift
@@ -533,7 +533,7 @@ public class ConnectButtonController {
     /// - appHandoff: Links to the IFTTT app to complete the connection flow
     /// - enterEmail: If we don't yet know the user, show the email field
     /// - identifyUser: We will have an email address or an IFTTT service token. Use this information to determine if they are already an IFTTT user. Obviously they are if we have an IFTTT token, but we still need to get their username.
-    /// - activateConnection: Go to the web or the IFTTT app to activate this Connection
+    /// - activateConnection: Go to the web or the IFTTT app to activate this Connection. RedirectImmediately will cause the button to skip showing the going to service progress bar.
     /// - activationComplete: Connection activation was successful. This always originates from a redirect. Passes the user token if it was included in the redirect.
     /// - failed: The `Connection` could not be authorized due to some error.
     /// - canceled: The `Connection` authorization was canceled.


### PR DESCRIPTION
https://ifttt-dev.atlassian.net/browse/IFTTT-1821

### What It Does

- Adjusts the `activateConnection` to allow for immediate redirection.

- If we have an existing user we skip the going to service step.


### How To Test

- Run the app and try to connect when using an existing account.

- Make sure you don't have the new iOS app installed.
