### PR TITLE
IFTTT-1798: Adjusting how connect button border works

### DIFF
--- a/IFTTT SDK/ConnectButton.swift
+++ b/IFTTT SDK/ConnectButton.swift
@@ -8,28 +8,29 @@
 
 import UIKit
 
-// Layout constants
-
-fileprivate struct Layout {
-    static let height: CGFloat = 70
-    static let maximumWidth = 4.7 * height
-    static let knobInset: CGFloat = borderWidth + 3
-    static let knobDiameter = height - 2 * knobInset
-    static let checkmarkDiameter: CGFloat = 42
-    static let checkmarkLength: CGFloat = 14
-    static let serviceIconDiameter = 0.5 * knobDiameter
-    static let borderWidth: CGFloat = 2
-    /// The amount by which the email field is offset from the center
-    static let emailFieldOffset: CGFloat = 4
-    static let buttonFooterSpacing: CGFloat = 15
-}
-
-
 // MARK: - Connect Button
 
 @available(iOS 10.0, *)
 @IBDesignable
 public class ConnectButton: UIView {
+    
+    // Layout constants
+    struct Layout {
+        fileprivate static let height: CGFloat = 70
+        fileprivate static let maximumWidth = 4.7 * height
+        fileprivate static let knobInset: CGFloat = borderWidth + 3
+        fileprivate static let knobDiameter = height - 2 * knobInset
+        fileprivate static let checkmarkDiameter: CGFloat = 42
+        fileprivate static let checkmarkLength: CGFloat = 14
+        fileprivate static let serviceIconDiameter = 0.5 * knobDiameter
+        
+        /// The thickness of the border around the the connect button.
+        static let borderWidth: CGFloat = 4
+        
+        /// The amount by which the email field is offset from the center
+        fileprivate static let emailFieldOffset: CGFloat = 4
+        fileprivate static let buttonFooterSpacing: CGFloat = 15
+    }
     
     /// Adjusts the button for a white or black background
     ///
@@ -987,9 +988,7 @@ public class ConnectButton: UIView {
         
         backgroundView.heightAnchor.constraint(equalToConstant: Layout.height).isActive = true
         
-        // Because we draw the border 1 pixel outside of the backgroundView, we need to adjust the progress bar to be inset the border width minus 1 to make sure it fills the full space.
-        let adjustBorderInsetValue = Layout.borderWidth - 1
-        progressBar.constrain.edges(to: backgroundView, inset: UIEdgeInsets(top: adjustBorderInsetValue, left: adjustBorderInsetValue, bottom: adjustBorderInsetValue, right: adjustBorderInsetValue))
+        progressBar.constrain.edges(to: backgroundView)
         
         primaryLabelAnimator.primary.view.constrain.edges(to: backgroundView)
         primaryLabelAnimator.transition.view.constrain.edges(to: backgroundView)

--- a/IFTTT SDK/PillView.swift
+++ b/IFTTT SDK/PillView.swift
@@ -154,7 +154,7 @@ class PillView: UIView {
         addSubview(bottomBorder)
         
         // In order to make sure the border always draws completely over the view it is pinned to, we need to offset the border to be slightly bigger then the pinned view.
-        let topBottomBorderInset = UIEdgeInsets(top: -1, left: 0, bottom: -1, right: 0)
+        let topBottomBorderInset = UIEdgeInsets(top: -ConnectButton.Layout.borderWidth, left: 0, bottom: -ConnectButton.Layout.borderWidth, right: 0)
         
         topBorder.constrain.edges(to: centerView, edges: [.left, .top, .right], inset: topBottomBorderInset)
         topBorderHeight.isActive = true
@@ -163,7 +163,7 @@ class PillView: UIView {
         bottomBorderHeight.isActive = true
         
         // In order to make sure the border always draws completely over the view it is pinned to, we need to offset the border to be slightly bigger then the pinned view.
-        let leftRightBorderInset = UIEdgeInsets(top: -1, left: -1, bottom: -1, right: -1)
+        let leftRightBorderInset = UIEdgeInsets(top: -ConnectButton.Layout.borderWidth, left: -ConnectButton.Layout.borderWidth, bottom: -ConnectButton.Layout.borderWidth, right: -ConnectButton.Layout.borderWidth)
         
         leftBorder.constrain.edges(to: leftCapView, inset: leftRightBorderInset)
         rightBorder.constrain.edges(to: rightCapView, inset: leftRightBorderInset)


### PR DESCRIPTION
https://ifttt-dev.atlassian.net/browse/IFTTT-1798

### What It Does

- Adjusts how we draw the border of the button so that in the light mode we draw a white border for consistency.

- Makes the border draw 1 pixel outside of the view it outlines to make sure there is no view behind that bleeds through. This also simulates drawing a border from the outside.

- Adjusts how the progress bar insets so that it always matches the border so the button is full filled when showing progress.

- Adjusts the inset to be based on the border width.

### Screenshots
![Simulator Screen Shot - iPhone X - 2019-05-22 at 14 28 28](https://user-images.githubusercontent.com/16432044/58199471-8801b100-7c9e-11e9-961c-fc04268abadc.png)
![Simulator Screen Shot - iPhone X - 2019-05-22 at 14 28 34](https://user-images.githubusercontent.com/16432044/58199476-8c2dce80-7c9e-11e9-990c-ec3e41615e23.png)
