### PR TITLE
Connect button textfield overlap fix

### DIFF
--- a/IFTTT SDK/ConnectButton.swift
+++ b/IFTTT SDK/ConnectButton.swift
@@ -573,6 +573,15 @@ private extension ConnectButton {
     
     private func transitionToLoadingFailed() {
         stopPulseAnimation()
+        resetEmailState()
+    }
+    
+    private func resetEmailState() {
+        emailEntryField.text = nil
+        emailEntryField.alpha = 0.0
+        emailConfirmButton.transform = .identity
+        emailConfirmButton.maskedEndCaps = .all
+        emailConfirmButton.alpha = 0
     }
     
     private func transitionToConnect(service: Service, message: String, animator: UIViewPropertyAnimator) {
@@ -581,6 +590,8 @@ private extension ConnectButton {
         primaryLabelAnimator.transition(updatedValue: .text(message), insets: .avoidLeftKnob, addingTo: animator)
         switchControl.configure(with: service, networkController: self.imageViewNetworkController, trackColor: trackColor)
         emailConfirmButton.backgroundColor = service.brandColor
+        
+        resetEmailState()
         
         animator.addAnimations {
             self.progressBar.alpha = 0


### PR DESCRIPTION
Resetting state of the email textfield and corresponding components when setting up connect button