### PR TITLE
Translation fallback

### DIFF
--- a/IFTTT SDK/LocalizedStrings.swift
+++ b/IFTTT SDK/LocalizedStrings.swift
@@ -28,9 +28,16 @@ extension String {
                                      value: "",
                                      comment: "")
         }
-        else {
+        else if let languageCode = locale.languageCode,
+            let languageTableFallbackPath = bundle.path(forResource: "Localizable_\(languageCode)", ofType: "strings"),
+            FileManager.default.fileExists(atPath: languageTableFallbackPath) {
             #if DEBUG
-                print("The key \(self) wasn't found in a strings file with name \(table) in the the bundle. Will fallback to the Localizable.strings file. Try reinstalling the SDK and then perform a clean/rebuild")
+                print("The key \(self) wasn't found in a strings file with name \(table) in the the bundle. Will try to fallback to Localizable_\(languageCode).strings file. Try reinstalling the SDK and then perform a clean/rebuild")
+            #endif
+            return NSLocalizedString(self, tableName: "Localizable_\(languageCode)", bundle: bundle, value: "", comment: "")
+        } else {
+            #if DEBUG
+                print("The key \(self) wasn't found in a strings file with name \(table) in the the bundle. Will try to fallback to Localizable.strings file. Try reinstalling the SDK and then perform a clean/rebuild")
             #endif
             return NSLocalizedString(self, bundle: bundle, value: "", comment: "")
         }

--- a/IFTTTConnectSDK.podspec
+++ b/IFTTTConnectSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name             = "IFTTTConnectSDK"
-  spec.version          = "2.4.0"
+  spec.version          = "2.4.1"
   spec.summary          = "Allows your users to activate programmable IFTTT Connections directly in your app."
   spec.description      = <<-DESC
   - Easily authenticate your services to IFTTT through the Connect Button

--- a/README.md
+++ b/README.md
@@ -379,7 +379,6 @@ Text translation is supported for the following languages:
 * German (de)
 * Spanish (es)
 * Spanish - Latin America and Caribbean region (es-419)
-* Spanish - United States (es-US)
 * Finnish (fi)
 * French (fr)
 * French - Canada (fr-CA)


### PR DESCRIPTION
Ensure that we fallback to base language translations if we're missing translations for a given region.