### PR TITLE
Duplicate region identifier registration fix

### DIFF
--- a/Examples/Podfile.lock
+++ b/Examples/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - IFTTTConnectSDK (2.5.0)
+  - IFTTTConnectSDK (2.5.2)
 
 DEPENDENCIES:
   - IFTTTConnectSDK (from `./../`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: "./../"
 
 SPEC CHECKSUMS:
-  IFTTTConnectSDK: 793cd84f5ef9c4070f425debc923439a0fb234d4
+  IFTTTConnectSDK: 16bb23ffd1cd26e1ed5103c7c938a07a07da8fd5
 
 PODFILE CHECKSUM: af7656f7e18efa570ba8f674c004512bed06a55e
 

--- a/Examples/Pods/Local Podspecs/IFTTTConnectSDK.podspec.json
+++ b/Examples/Pods/Local Podspecs/IFTTTConnectSDK.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "IFTTTConnectSDK",
-  "version": "2.5.0",
+  "version": "2.5.2",
   "summary": "Allows your users to activate programmable IFTTT Connections directly in your app.",
   "description": "- Easily authenticate your services to IFTTT through the Connect Button\n- Configure the Connect Button through code or through interface builder with IBDesignable\n- Configure the ConnectButtonController to handle the Connection activation flow",
   "homepage": "https://github.com/IFTTT/ConnectSDK-iOS",
@@ -17,7 +17,7 @@
   "swift_versions": "5.0",
   "source": {
     "git": "https://github.com/IFTTT/ConnectSDK-iOS.git",
-    "tag": "2.5.0"
+    "tag": "2.5.2"
   },
   "source_files": "IFTTT SDK/**/*.swift",
   "resource_bundles": {

--- a/Examples/Pods/Manifest.lock
+++ b/Examples/Pods/Manifest.lock
@@ -1,5 +1,5 @@
 PODS:
-  - IFTTTConnectSDK (2.5.0)
+  - IFTTTConnectSDK (2.5.2)
 
 DEPENDENCIES:
   - IFTTTConnectSDK (from `./../`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: "./../"
 
 SPEC CHECKSUMS:
-  IFTTTConnectSDK: 793cd84f5ef9c4070f425debc923439a0fb234d4
+  IFTTTConnectSDK: 16bb23ffd1cd26e1ed5103c7c938a07a07da8fd5
 
 PODFILE CHECKSUM: af7656f7e18efa570ba8f674c004512bed06a55e
 

--- a/Examples/Pods/Target Support Files/IFTTTConnectSDK/ResourceBundle-IFTTTConnectSDK-IFTTTConnectSDK-Info.plist
+++ b/Examples/Pods/Target Support Files/IFTTTConnectSDK/ResourceBundle-IFTTTConnectSDK-IFTTTConnectSDK-Info.plist
@@ -13,7 +13,7 @@
   <key>CFBundlePackageType</key>
   <string>BNDL</string>
   <key>CFBundleShortVersionString</key>
-  <string>2.5.0</string>
+  <string>2.5.2</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>

--- a/Examples/Pods/Target Support Files/IFTTTConnectSDK/ResourceBundle-IFTTTConnectSDK-Localizations-IFTTTConnectSDK-Info.plist
+++ b/Examples/Pods/Target Support Files/IFTTTConnectSDK/ResourceBundle-IFTTTConnectSDK-Localizations-IFTTTConnectSDK-Info.plist
@@ -13,7 +13,7 @@
   <key>CFBundlePackageType</key>
   <string>BNDL</string>
   <key>CFBundleShortVersionString</key>
-  <string>2.5.0</string>
+  <string>2.5.2</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>


### PR DESCRIPTION
Fixing a bug where a region with a duplicate identifier wouldn't get updated with the system's region monitoring