### PR TITLE
Fixing a race condition in the scheduler

### DIFF
--- a/IFTTT SDK/ConnectionsSynchronizer.swift
+++ b/IFTTT SDK/ConnectionsSynchronizer.swift
@@ -184,8 +184,6 @@ final class ConnectionsSynchronizer {
     
     /// Call this to stop the synchronization completely. Safe to be called multiple times.
     private func stop() {
-        if state == .stopped { return }
-        
         stopNotifications()
         Keychain.resetIfNecessary(force: true)
         scheduler.stop()

--- a/IFTTT SDK/ConnectionsSynchronizer.swift
+++ b/IFTTT SDK/ConnectionsSynchronizer.swift
@@ -106,7 +106,7 @@ final class ConnectionsSynchronizer {
                                        eventPublisher: eventPublisher)
         
         let connectionsMonitor = ConnectionsMonitor(connectionsRegistry: connectionsRegistry)
-        let nativeServicesCoordinator = NativeServicesCoordinator(locationService: location)
+        let nativeServicesCoordinator = NativeServicesCoordinator(locationService: location, permissionsRequestor: permissionsRequestor)
 
         self.subscribers = [
             connectionsMonitor,
@@ -263,15 +263,18 @@ final class ConnectionsSynchronizer {
 /// Handles coordination of native services with a set of connections
 private class NativeServicesCoordinator {
     private let locationService: LocationService
+    private let permissionsRequestor: PermissionsRequestor
     private let operationQueue: OperationQueue
     
-    init(locationService: LocationService) {
+    init(locationService: LocationService, permissionsRequestor: PermissionsRequestor) {
         self.locationService = locationService
+        self.permissionsRequestor = permissionsRequestor
         self.operationQueue = OperationQueue.main
     }
     
     func processConnectionUpdate(_ updates: Set<Connection.ConnectionStorage>) {
         operationQueue.addOperation {
+            self.permissionsRequestor.processUpdate(with: updates)
             self.locationService.updateRegions(from: updates)
         }
     }

--- a/IFTTT SDK/Keychain.swift
+++ b/IFTTT SDK/Keychain.swift
@@ -95,7 +95,7 @@ final class Keychain {
     }
     
     private class func reset() {
-        Key.AllCases().forEach {
+        Key.allCases.forEach {
             removeValue(for: $0)
         }
     }

--- a/IFTTT SDK/PermissionsRequestor.swift
+++ b/IFTTT SDK/PermissionsRequestor.swift
@@ -24,7 +24,7 @@ final class PermissionsRequestor: SynchronizationSubscriber {
         self.registry = registry
     }
 
-    private func processUpdate(with connections: Set<Connection.ConnectionStorage>) {
+    func processUpdate(with connections: Set<Connection.ConnectionStorage>) {
         let operations = connections.reduce(.init()) { (currSet, connections) -> Set<Trigger> in
             return currSet.union(connections.allTriggers)
         }

--- a/IFTTTConnectSDK.podspec
+++ b/IFTTTConnectSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name             = "IFTTTConnectSDK"
-  spec.version          = "2.5.8"
+  spec.version          = "2.5.9"
   spec.summary          = "Allows your users to activate programmable IFTTT Connections directly in your app."
   spec.description      = <<-DESC
   - Easily authenticate your services to IFTTT through the Connect Button


### PR DESCRIPTION
This fixes an issue where the sub components of the SDK would get updated before the request for the user's connections would finish