### PR TITLE
CI Fix - Bump simulator version to 15.2

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -18,7 +18,7 @@ jobs:
         env:
           scheme: ${{ 'SDKHostApp' }}
           platform: ${{ 'iOS Simulator' }}
-          os: ${{ '15.0' }}
+          os: ${{ '15.2' }}
           device: ${{ 'iPhone 13' }}
         run: |
           # xcrun xctrace returns via stderr, not the expected stdout (see https://developer.apple.com/forums/thread/663959)
@@ -30,8 +30,8 @@ jobs:
         env:
           scheme: ${{ 'SDKHostApp' }}
           platform: ${{ 'iOS Simulator' }}
-          os: ${{ '15.0' }}
-          device: ${{ 'iPhone 13' }}        
+          os: ${{ '15.2' }}
+          device: ${{ 'iPhone 13' }}
         run: |
           # xcrun xctrace returns via stderr, not the expected stdout (see https://developer.apple.com/forums/thread/663959)
           if [ $scheme = default ]; then scheme=$(cat default); fi


### PR DESCRIPTION
All simulators available on the build host are on iOS 15.2

Current error:
```
xcodebuild: error: Unable to find a destination matching the provided destination specifier:
		{ platform:iOS Simulator, OS:15.0, name:iPhone 13 }
```