### PR TITLE
Fix Swift compiler warnings

### DIFF
--- a/IFTTT SDK/ConnectButton.swift
+++ b/IFTTT SDK/ConnectButton.swift
@@ -345,7 +345,7 @@ public class ConnectButton: UIView {
             footerLabel.constrain.edges(to: footerLabelContainer, edges: [.left, .top, .right])
             
             // But allow it to be shorter than its container
-            footerLabel.bottomAnchor.constraint(lessThanOrEqualTo: footerLabelContainer.bottomAnchor)
+            footerLabel.bottomAnchor.constraint(lessThanOrEqualTo: footerLabelContainer.bottomAnchor).isActive = true
             let breakableBottomConstraint = footerLabel.bottomAnchor.constraint(equalTo: footerLabelContainer.bottomAnchor)
             breakableBottomConstraint.priority = .defaultHigh
             

--- a/IFTTT SDK/SignInWithAppleAuthentication.swift
+++ b/IFTTT SDK/SignInWithAppleAuthentication.swift
@@ -41,6 +41,27 @@ final class AppleSignInWebService: ServiceAuthentication {
         @available(iOS 13.0, *)
         func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
             let authorizationError = ASAuthorizationError(_nsError: error as NSError)
+            // Cases added after the SDK's iOS 14.2 deployment target.
+            // Each is referenced behind an availability check and mapped
+            // to the matching AuthenticationError case so callers can
+            // distinguish it from the generic .failed / .unknown bucket.
+            if #available(iOS 15.4, *), authorizationError.code == .notInteractive {
+                completion(.failure(.notInteractive))
+                return
+            }
+            if #available(iOS 18.0, *), authorizationError.code == .matchedExcludedCredential {
+                completion(.failure(.matchedExcludedCredential))
+                return
+            }
+            if #available(iOS 18.2, *), authorizationError.code == .credentialImport {
+                completion(.failure(.credentialImport))
+                return
+            }
+            if #available(iOS 18.2, *), authorizationError.code == .credentialExport {
+                completion(.failure(.credentialExport))
+                return
+            }
+
             switch authorizationError.code {
             case .canceled:
                 completion(.failure(.userCanceled))

--- a/IFTTT SDK/WebServiceAuthentication.swift
+++ b/IFTTT SDK/WebServiceAuthentication.swift
@@ -14,6 +14,15 @@ import AuthenticationServices
 /// - invalidResponse: The response returned by the web service was invalid.
 /// - notHandled: The error wasn't handled by the web service.
 /// - presentationContextInvalid: The presentation content provided was invalid.
+/// - notInteractive: The authorization request was performed in a
+///   non-interactive context. Mirrors `ASAuthorizationError.notInteractive`
+///   (iOS 15.4+).
+/// - matchedExcludedCredential: A matched credential was excluded from use.
+///   Mirrors `ASAuthorizationError.matchedExcludedCredential` (iOS 18+).
+/// - credentialImport: An error occurred importing a credential. Mirrors
+///   `ASAuthorizationError.credentialImport` (iOS 18.2+).
+/// - credentialExport: An error occurred exporting a credential. Mirrors
+///   `ASAuthorizationError.credentialExport` (iOS 18.2+).
 /// - unknown: Some unknown error ocurred when authenticating with the web service.
 enum AuthenticationError: Error {
     case userCanceled
@@ -21,6 +30,10 @@ enum AuthenticationError: Error {
     case invalidResponse
     case notHandled
     case presentationContextInvalid
+    case notInteractive
+    case matchedExcludedCredential
+    case credentialImport
+    case credentialExport
     case unknown
 }
 


### PR DESCRIPTION
## Summary

### `ConnectButton.swift`
The `constraint(lessThanOrEqualTo:)` call on line 348 was never activated, leaving the "label bottom must not exceed container bottom" relationship dangling. The compiler flagged the unused result. Activate it explicitly — matches the clear intent of the comment above it.

### `AuthenticationError` + `SignInWithAppleAuthentication.swift`
Apple has added new `ASAuthorizationError.Code` cases since the SDK was written. Add matching cases to `AuthenticationError` and map 1:1 so callers see the real Apple-side reason instead of being funneled into a generic `.failed` / `.unknown` bucket.

| `ASAuthorizationError.Code` | New `AuthenticationError` case | Since |
|---|---|---|
| `.notInteractive` | `.notInteractive` | iOS 15.4 |
| `.matchedExcludedCredential` | `.matchedExcludedCredential` | iOS 18.0 |
| `.credentialImport` | `.credentialImport` | iOS 18.2 |
| `.credentialExport` | `.credentialExport` | iOS 18.2 |

Each Apple case is referenced behind an `if #available` check so the SDK still builds at its iOS 14.2 deployment target. The original switch (with `@unknown default`) is kept as a safety net for future Apple additions. This also clears the "switch must be exhaustive" warning that newer compilers raised against the previous iOS-13-only case set.

## Test plan
- [ ] Build the SDK against the latest Xcode — no warnings on `ConnectButton.swift:348` or `SignInWithAppleAuthentication.swift:44`
- [ ] Connect button footer layout visually unchanged in the host app
- [ ] Sign-in-with-Apple: canceled / failed / invalidResponse / notHandled / unknown flows surface expected errors
- [ ] Sign-in-with-Apple on iOS 18.2+: passkey exclude-list and credential-import/export error paths surface their new dedicated `AuthenticationError` cases