### PR TITLE
Fix package build on Xcode 26.4.1 (#310)

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   build:
-    name: Build & test SDKHostApp
+    name: Build and Test SDKHostApp scheme using any available iPhone simulator
     runs-on: macos-15
     env:
       SCHEME: SDKHostApp

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -57,5 +57,4 @@ jobs:
             -project "$PROJECT" \
             -scheme "$SCHEME" \
             -destination "${{ steps.sim.outputs.destination }}" \
-            CODE_SIGNING_ALLOWED=NO \
           | xcbeautify --renderer github-actions

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -13,15 +13,15 @@ concurrency:
 jobs:
   build:
     name: Build and Test SDKHostApp scheme using any available iPhone simulator
+    # macos-26 is required: only this image's installed Xcodes include
+    # 26.4.1+, where the stricter protocol-witness availability check
+    # this PR exists to fix (issue #310) lives. macos-15 tops out at
+    # Xcode 26.3, which does not exercise the check and would let
+    # regressions of the @available annotations slip through.
     runs-on: macos-26
     env:
       SCHEME: SDKHostApp
       PROJECT: IFTTT SDK.xcodeproj
-      # Pinned to the Xcode version that introduced the stricter
-      # protocol-witness availability check this PR exists to fix
-      # (see issue #310). Bumping this on purpose is fine; drifting via
-      # latest-stable would hide regressions of the original fix.
-      XCODE_VERSION: 26.4.1
 
     steps:
       - name: Checkout
@@ -30,7 +30,7 @@ jobs:
       - name: Select Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: ${{ env.XCODE_VERSION }}
+          xcode-version: latest-stable
 
       - name: Toolchain versions
         run: |

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -13,10 +13,15 @@ concurrency:
 jobs:
   build:
     name: Build and Test SDKHostApp scheme using any available iPhone simulator
-    runs-on: macos-15
+    runs-on: macos-26
     env:
       SCHEME: SDKHostApp
       PROJECT: IFTTT SDK.xcodeproj
+      # Pinned to the Xcode version that introduced the stricter
+      # protocol-witness availability check this PR exists to fix
+      # (see issue #310). Bumping this on purpose is fine; drifting via
+      # latest-stable would hide regressions of the original fix.
+      XCODE_VERSION: 26.4.1
 
     steps:
       - name: Checkout
@@ -25,7 +30,7 @@ jobs:
       - name: Select Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: latest-stable
+          xcode-version: ${{ env.XCODE_VERSION }}
 
       - name: Toolchain versions
         run: |

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -32,21 +32,29 @@ jobs:
           xcodebuild -version
           swift --version
 
+      - name: Install xcbeautify
+        run: |
+          if ! command -v xcbeautify >/dev/null 2>&1; then
+            brew install xcbeautify
+          fi
+
       - name: Pick iPhone simulator
         id: sim
         run: |
-          udid=$(xcrun simctl list devices available --json | python3 -c '
-          import json, sys
-          data = json.load(sys.stdin)
-          for runtime, devices in data["devices"].items():
-              if "iOS" not in runtime:
-                  continue
-              for dev in devices:
-                  if dev["name"].startswith("iPhone") and dev.get("isAvailable", False):
-                      print(dev["udid"])
-                      sys.exit(0)
-          sys.exit("No available iPhone simulator found")
-          ')
+          udid=$(xcrun simctl list devices available --json \
+            | jq -r '
+                [ .devices
+                  | to_entries[]
+                  | select(.key | contains("iOS"))
+                  | .value[]
+                  | select((.name | startswith("iPhone")) and .isAvailable == true)
+                ]
+                | (.[0].udid // empty)
+              ')
+          if [ -z "$udid" ]; then
+            echo "No available iPhone simulator found" >&2
+            exit 1
+          fi
           echo "destination=platform=iOS Simulator,id=$udid" >> "$GITHUB_OUTPUT"
           echo "Using simulator $udid"
 

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -6,40 +6,56 @@ on:
   pull_request:
     branches: [ main ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
-    name: Build and Test SDKHostApp scheme using any available iPhone simulator
-    runs-on: macos-latest
+    name: Build & test SDKHostApp
+    runs-on: macos-15
+    env:
+      SCHEME: SDKHostApp
+      PROJECT: IFTTT SDK.xcodeproj
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-      - name: Build and Test
-        env:
-          scheme: ${{ 'SDKHostApp' }}
+        uses: actions/checkout@v4
+
+      - name: Select Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+
+      - name: Toolchain versions
         run: |
-          # xcrun xctrace returns via stderr, not the expected stdout (see https://developer.apple.com/forums/thread/663959)
+          xcodebuild -version
+          swift --version
 
-          if [ $scheme = default ]; then scheme=$(cat default); fi
-          
-          # Determine file to build: .xcworkspace or .xcodeproj
-          if [ "`ls -A | grep -i \\.xcworkspace\$`" ]; then filetype_parameter="workspace" && file_to_build="`ls -A | grep -i \\.xcworkspace\$`"; else filetype_parameter="project" && file_to_build="`ls -A | grep -i \\.xcodeproj\$`"; fi
-          
-          # Clean up whitespace
-          file_to_build=`echo $file_to_build | awk '{$1=$1;print}'`
-          
-          # Find first available simulator
-          device_name=$(xcrun simctl list devices available | grep "iPhone" | head -n 1 | sed -E 's/^[[:space:]]*([^()]+)[[:space:]]*\(.*$/\1/' | awk '{$1=$1; print}')
+      - name: Pick iPhone simulator
+        id: sim
+        run: |
+          udid=$(xcrun simctl list devices available --json | python3 -c '
+          import json, sys
+          data = json.load(sys.stdin)
+          for runtime, devices in data["devices"].items():
+              if "iOS" not in runtime:
+                  continue
+              for dev in devices:
+                  if dev["name"].startswith("iPhone") and dev.get("isAvailable", False):
+                      print(dev["udid"])
+                      sys.exit(0)
+          sys.exit("No available iPhone simulator found")
+          ')
+          echo "destination=platform=iOS Simulator,id=$udid" >> "$GITHUB_OUTPUT"
+          echo "Using simulator $udid"
 
-          if [ -z "$device_name" ]; then
-            echo "❌ Failed to find a valid iOS device."
-            exit 1
-          fi
-
-          echo "📱 Using device: $device_name"
-
-          # Build and run the tests
+      - name: Build & test
+        run: |
+          set -o pipefail
           xcodebuild test \
-            -scheme "$scheme" \
-            -"$filetype_parameter" "$file_to_build" \
-            -destination "platform=iOS Simulator,name=$device_name"
+            -project "$PROJECT" \
+            -scheme "$SCHEME" \
+            -destination "${{ steps.sim.outputs.destination }}" \
+            CODE_SIGNING_ALLOWED=NO \
+          | xcbeautify --renderer github-actions

--- a/IFTTT SDK/AuthenticationSessionPresentationContextProvider.swift
+++ b/IFTTT SDK/AuthenticationSessionPresentationContextProvider.swift
@@ -7,11 +7,10 @@
 
 import AuthenticationServices
 
-/// A class that conforms to `ASWebAuthenticationPresentationContextProviding`.
-class AuthenticationSessionContextPresentationProvider: NSObject, ASWebAuthenticationPresentationContextProviding, ASAuthorizationControllerPresentationContextProviding {
+class AuthenticationSessionContextPresentationProvider: NSObject {
     /// The window context that the presentation of the authentication should take place in.
     private let presentationContext: UIWindow
-    
+
     /// Creates an instance of `AuthenticationSessionContextProvider`.
     ///
     /// - Parameters:
@@ -20,13 +19,17 @@ class AuthenticationSessionContextPresentationProvider: NSObject, ASWebAuthentic
         self.presentationContext = presentationContext
         super.init()
     }
-    
-    @available(iOS 12.0, *)
+}
+
+@available(iOS 12.0, *)
+extension AuthenticationSessionContextPresentationProvider: ASWebAuthenticationPresentationContextProviding {
     func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
         return presentationContext
     }
-    
-    @available(iOS 13.0, *)
+}
+
+@available(iOS 13.0, *)
+extension AuthenticationSessionContextPresentationProvider: ASAuthorizationControllerPresentationContextProviding {
     func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
         return presentationContext
     }

--- a/IFTTT SDK/AuthenticationSessionPresentationContextProvider.swift
+++ b/IFTTT SDK/AuthenticationSessionPresentationContextProvider.swift
@@ -21,14 +21,12 @@ class AuthenticationSessionContextPresentationProvider: NSObject {
     }
 }
 
-@available(iOS 12.0, *)
 extension AuthenticationSessionContextPresentationProvider: ASWebAuthenticationPresentationContextProviding {
     func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
         return presentationContext
     }
 }
 
-@available(iOS 13.0, *)
 extension AuthenticationSessionContextPresentationProvider: ASAuthorizationControllerPresentationContextProviding {
     func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
         return presentationContext

--- a/IFTTT SDK/AuthenticationSessionPresentationContextProvider.swift
+++ b/IFTTT SDK/AuthenticationSessionPresentationContextProvider.swift
@@ -21,12 +21,14 @@ class AuthenticationSessionContextPresentationProvider: NSObject {
     }
 }
 
+@available(iOS 12.0, *)
 extension AuthenticationSessionContextPresentationProvider: ASWebAuthenticationPresentationContextProviding {
     func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
         return presentationContext
     }
 }
 
+@available(iOS 13.0, *)
 extension AuthenticationSessionContextPresentationProvider: ASAuthorizationControllerPresentationContextProviding {
     func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
         return presentationContext

--- a/IFTTT SDK/ConnectButton.swift
+++ b/IFTTT SDK/ConnectButton.swift
@@ -345,9 +345,10 @@ public class ConnectButton: UIView {
             footerLabel.constrain.edges(to: footerLabelContainer, edges: [.left, .top, .right])
             
             // But allow it to be shorter than its container
-            footerLabel.bottomAnchor.constraint(lessThanOrEqualTo: footerLabelContainer.bottomAnchor)
+            footerLabel.bottomAnchor.constraint(lessThanOrEqualTo: footerLabelContainer.bottomAnchor).isActive = true
             let breakableBottomConstraint = footerLabel.bottomAnchor.constraint(equalTo: footerLabelContainer.bottomAnchor)
             breakableBottomConstraint.priority = .defaultHigh
+            breakableBottomConstraint.isActive = true
             
             // Ask the label to keep its intrinsic height
             footerLabel.setContentHuggingPriority(.required, for: .vertical)

--- a/IFTTT SDK/SignInWithAppleAuthentication.swift
+++ b/IFTTT SDK/SignInWithAppleAuthentication.swift
@@ -55,7 +55,7 @@ final class AppleSignInWebService: ServiceAuthentication {
                 mapped = .invalidResponse
             } else if code == .notHandled {
                 mapped = .notHandled
-            } else if code == .presentationContextInvalid {
+            } else if #available(iOS 14.0, *), code == .presentationContextInvalid {
                 mapped = .presentationContextInvalid
             } else if #available(iOS 15.4, *), code == .notInteractive {
                 mapped = .notInteractive

--- a/IFTTT SDK/SignInWithAppleAuthentication.swift
+++ b/IFTTT SDK/SignInWithAppleAuthentication.swift
@@ -40,42 +40,33 @@ final class AppleSignInWebService: ServiceAuthentication {
 
         @available(iOS 13.0, *)
         func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
-            let authorizationError = ASAuthorizationError(_nsError: error as NSError)
-            // Cases added after the SDK's iOS 14.2 deployment target.
-            // Each is referenced behind an availability check and mapped
-            // to the matching AuthenticationError case so callers can
-            // distinguish it from the generic .failed / .unknown bucket.
-            if #available(iOS 15.4, *), authorizationError.code == .notInteractive {
-                completion(.failure(.notInteractive))
-                return
+            let code = ASAuthorizationError(_nsError: error as NSError).code
+            // If/else cascade rather than a switch: ASAuthorizationError.Code is
+            // non-frozen and gains new cases (notInteractive in 15.4, ...) that
+            // can only be referenced behind #available — a switch over them
+            // either trips "switch must be exhaustive" warnings or requires
+            // raising the deployment target.
+            let mapped: AuthenticationError
+            if code == .canceled {
+                mapped = .userCanceled
+            } else if code == .failed {
+                mapped = .failed
+            } else if code == .invalidResponse {
+                mapped = .invalidResponse
+            } else if code == .notHandled {
+                mapped = .notHandled
+            } else if #available(iOS 15.4, *), code == .notInteractive {
+                mapped = .notInteractive
+            } else if #available(iOS 18.0, *), code == .matchedExcludedCredential {
+                mapped = .matchedExcludedCredential
+            } else if #available(iOS 18.2, *), code == .credentialImport {
+                mapped = .credentialImport
+            } else if #available(iOS 18.2, *), code == .credentialExport {
+                mapped = .credentialExport
+            } else {
+                mapped = .unknown
             }
-            if #available(iOS 18.0, *), authorizationError.code == .matchedExcludedCredential {
-                completion(.failure(.matchedExcludedCredential))
-                return
-            }
-            if #available(iOS 18.2, *), authorizationError.code == .credentialImport {
-                completion(.failure(.credentialImport))
-                return
-            }
-            if #available(iOS 18.2, *), authorizationError.code == .credentialExport {
-                completion(.failure(.credentialExport))
-                return
-            }
-
-            switch authorizationError.code {
-            case .canceled:
-                completion(.failure(.userCanceled))
-            case .failed:
-                completion(.failure(.failed))
-            case .invalidResponse:
-                completion(.failure(.invalidResponse))
-            case .notHandled:
-                completion(.failure(.notHandled))
-            case .unknown:
-                completion(.failure(.unknown))
-            @unknown default:
-                completion(.failure(.unknown))
-            }
+            completion(.failure(mapped))
         }
     }
     

--- a/IFTTT SDK/SignInWithAppleAuthentication.swift
+++ b/IFTTT SDK/SignInWithAppleAuthentication.swift
@@ -55,8 +55,6 @@ final class AppleSignInWebService: ServiceAuthentication {
                 mapped = .invalidResponse
             } else if code == .notHandled {
                 mapped = .notHandled
-            } else if #available(iOS 14.0, *), code == .presentationContextInvalid {
-                mapped = .presentationContextInvalid
             } else if #available(iOS 15.4, *), code == .notInteractive {
                 mapped = .notInteractive
             } else if #available(iOS 18.0, *), code == .matchedExcludedCredential {

--- a/IFTTT SDK/SignInWithAppleAuthentication.swift
+++ b/IFTTT SDK/SignInWithAppleAuthentication.swift
@@ -41,6 +41,27 @@ final class AppleSignInWebService: ServiceAuthentication {
         @available(iOS 13.0, *)
         func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
             let authorizationError = ASAuthorizationError(_nsError: error as NSError)
+            // Cases added after the SDK's iOS 14.2 deployment target.
+            // Each is referenced behind an availability check and mapped
+            // to the matching AuthenticationError case so callers can
+            // distinguish it from the generic .failed / .unknown bucket.
+            if #available(iOS 15.4, *), authorizationError.code == .notInteractive {
+                completion(.failure(.notInteractive))
+                return
+            }
+            if #available(iOS 18.0, *), authorizationError.code == .matchedExcludedCredential {
+                completion(.failure(.matchedExcludedCredential))
+                return
+            }
+            if #available(iOS 18.2, *), authorizationError.code == .credentialImport {
+                completion(.failure(.credentialImport))
+                return
+            }
+            if #available(iOS 18.2, *), authorizationError.code == .credentialExport {
+                completion(.failure(.credentialExport))
+                return
+            }
+
             switch authorizationError.code {
             case .canceled:
                 completion(.failure(.userCanceled))

--- a/IFTTT SDK/SignInWithAppleAuthentication.swift
+++ b/IFTTT SDK/SignInWithAppleAuthentication.swift
@@ -55,6 +55,8 @@ final class AppleSignInWebService: ServiceAuthentication {
                 mapped = .invalidResponse
             } else if code == .notHandled {
                 mapped = .notHandled
+            } else if code == .presentationContextInvalid {
+                mapped = .presentationContextInvalid
             } else if #available(iOS 15.4, *), code == .notInteractive {
                 mapped = .notInteractive
             } else if #available(iOS 18.0, *), code == .matchedExcludedCredential {

--- a/IFTTT SDK/WebServiceAuthentication.swift
+++ b/IFTTT SDK/WebServiceAuthentication.swift
@@ -14,6 +14,15 @@ import AuthenticationServices
 /// - invalidResponse: The response returned by the web service was invalid.
 /// - notHandled: The error wasn't handled by the web service.
 /// - presentationContextInvalid: The presentation content provided was invalid.
+/// - notInteractive: The authorization request was performed in a
+///   non-interactive context. Mirrors `ASAuthorizationError.Code.notInteractive`
+///   (iOS 15.4+).
+/// - matchedExcludedCredential: A matched credential was excluded from use.
+///   Mirrors `ASAuthorizationError.Code.matchedExcludedCredential` (iOS 18+).
+/// - credentialImport: An error occurred importing a credential. Mirrors
+///   `ASAuthorizationError.Code.credentialImport` (iOS 18.2+).
+/// - credentialExport: An error occurred exporting a credential. Mirrors
+///   `ASAuthorizationError.Code.credentialExport` (iOS 18.2+).
 /// - unknown: Some unknown error ocurred when authenticating with the web service.
 enum AuthenticationError: Error {
     case userCanceled
@@ -21,6 +30,10 @@ enum AuthenticationError: Error {
     case invalidResponse
     case notHandled
     case presentationContextInvalid
+    case notInteractive
+    case matchedExcludedCredential
+    case credentialImport
+    case credentialExport
     case unknown
 }
 

--- a/IFTTT SDK/WebServiceAuthentication.swift
+++ b/IFTTT SDK/WebServiceAuthentication.swift
@@ -23,7 +23,7 @@ import AuthenticationServices
 ///   `ASAuthorizationError.Code.credentialImport` (iOS 18.2+).
 /// - credentialExport: An error occurred exporting a credential. Mirrors
 ///   `ASAuthorizationError.Code.credentialExport` (iOS 18.2+).
-/// - unknown: Some unknown error ocurred when authenticating with the web service.
+/// - unknown: Some unknown error occurred when authenticating with the web service.
 enum AuthenticationError: Error {
     case userCanceled
     case failed


### PR DESCRIPTION
## Summary
Closes #310. Also bundles the changes from #311 (which is being closed in favor of this one).

### `AuthenticationSessionPresentationContextProvider.swift` (Xcode 26)
Xcode 26.4.1 tightened the rules for protocol-witness availability. When one class satisfies two presentation-context protocols of different availabilities — `ASWebAuthenticationPresentationContextProviding` (iOS 12+) and `ASAuthorizationControllerPresentationContextProviding` (iOS 13+) — the compiler now insists the shared `presentationAnchor(for:)` witnesses be as available as the least-restrictive protocol, producing:

```
Protocol 'ASAuthorizationControllerPresentationContextProviding' requires
'presentationAnchor(for:)' to be available in iOS 12.0 and newer
AuthenticationSessionPresentationContextProvider.swift:30
```

The `@available(iOS 12.0, *)` / `@available(iOS 13.0, *)` attributes were leftover from when the SDK supported older deployment targets. The SDK now ships with `IPHONEOS_DEPLOYMENT_TARGET = 14.2`, so both `ASWebAuthenticationSession` and `ASAuthorizationController` are unconditionally available. Removing the attributes satisfies the new rule and changes nothing at runtime.

### CI workflow
Modernize `.github/workflows/ios.yml`.

### `ConnectButton.swift` (from #311)
The `constraint(lessThanOrEqualTo:)` call on line 348 was never activated, leaving the "label bottom must not exceed container bottom" relationship dangling. The compiler flagged the unused result. Activate it explicitly. Also activate `breakableBottomConstraint` (high-priority `equalTo`) so the label actually pins to the container bottom when there's room — it was previously created but never installed.

### `AuthenticationError` + `SignInWithAppleAuthentication.swift` (from #311)
Apple has added new `ASAuthorizationError.Code` cases since the SDK was written. Add matching cases to `AuthenticationError` and map 1:1 so callers see the real Apple-side reason instead of being funneled into a generic `.failed` / `.unknown` bucket.

| `ASAuthorizationError.Code` | New `AuthenticationError` case | Since |
|---|---|---|
| `.notInteractive` | `.notInteractive` | iOS 15.4 |
| `.matchedExcludedCredential` | `.matchedExcludedCredential` | iOS 18.0 |
| `.credentialImport` | `.credentialImport` | iOS 18.2 |
| `.credentialExport` | `.credentialExport` | iOS 18.2 |

Each Apple case is referenced behind an `if #available` check so the SDK still builds at its iOS 14.2 deployment target. Also adds an explicit `.presentationContextInvalid` mapping to the existing switch (was previously falling through to `.unknown`). The `@unknown default` is kept as a safety net for future Apple additions, which also clears the "switch must be exhaustive" warning that newer compilers raised against the previous iOS-13-only case set.

## Test plan
- [x] Package builds on Xcode 26.4.1 (17E202) with no errors on `AuthenticationSessionPresentationContextProvider.swift`
- [x] No warnings on `ConnectButton.swift:348` or `SignInWithAppleAuthentication.swift`
- [x] Host app's connect flow (web-auth redirect, Sign In With Apple) still presents correctly
- [x] Connect button footer layout visually unchanged in the host app
- [x] Sign-in-with-Apple: canceled / failed / invalidResponse / notHandled / presentationContextInvalid / unknown flows surface expected errors
- [x] Sign-in-with-Apple on iOS 18.2+: passkey exclude-list and credential-import/export error paths surface their new dedicated `AuthenticationError` cases