### PR TITLE
Version bump to 2.9.0

### DIFF
--- a/IFTTTConnectSDK.podspec
+++ b/IFTTTConnectSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name             = "IFTTTConnectSDK"
-  spec.version          = "2.8.0"
+  spec.version          = "2.9.0"
   spec.summary          = "Allows your users to activate programmable IFTTT Connections directly in your app."
   spec.description      = <<-DESC
   - Easily authenticate your services to IFTTT through the Connect Button


### PR DESCRIPTION
## Summary
- Bumps `IFTTTConnectSDK.podspec` to `2.9.0` for tagging and CocoaPods publication.

This is the release-cut PR for the changes accumulated on `main` since `2.8.0` (Nov 2021), most notably the Xcode 26 / iOS 26 compatibility fixes from #312 and the Connect Button dark mode work from #298. After this merges, the `2.9.0` annotated tag will be cut on the merge commit and `pod trunk push` will publish to CocoaPods.

## Test plan
- [x] No source changes; only `IFTTTConnectSDK.podspec` is touched
- [x] CI green